### PR TITLE
Switch to markdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
-= 1.0.2 - 10-Apr-2016
+## 1.0.2 - 10-Apr-2016
 * This gem is now signed.
 * Updated the tests to use rspec 3 syntax.
 * Added an azure-profile.rb file for convenience.
 
-= 1.0.1 - 18-May-2015
-* Changed license to Apache 2.0 and added a license file.
+## 1.0.1 - 18-May-2015
+* Changed license to Apache-2.0 and added a license file.
 
-= 1.0.0 - 13-May-2015
+## 1.0.0 - 13-May-2015
 * Initial release

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,13 +1,13 @@
-CHANGES.md
-LICENSE
-MANIFEST.md
-README.md
-Rakefile
-azure-profile.gemspec
-lib/azure-profile.rb
-lib/azure/profile.rb
-lib/azure/profile/subscription.rb
-spec/azure_profile_spec.rb
-spec/azure_subscription_spec.rb
-spec/azureProfile.json
-spec/azure.publishsettings
+* CHANGES.md
+* LICENSE
+* MANIFEST.md
+* README.md
+* Rakefile
+* azure-profile.gemspec
+* lib/azure-profile.rb
+* lib/azure/profile.rb
+* lib/azure/profile/subscription.rb
+* spec/azure_profile_spec.rb
+* spec/azure_subscription_spec.rb
+* spec/azureProfile.json
+* spec/azure.publishsettings

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,7 +1,7 @@
-CHANGES
+CHANGES.md
 LICENSE
-MANIFEST
-README
+MANIFEST.md
+README.md
 Rakefile
 azure-profile.gemspec
 lib/azure-profile.rb

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This library possible courtesy of Red Hat, Inc.
 ## License
 Apache-2.0
 
-##= Warranty
+## Warranty
 This library is provided "as is" and without any express or
 implied warranties, including, without limitation, the implied
 warranties of merchantability and fitness for a particular purpose.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
-= Description
+# DEPRECATION WARNING
+This library was originally written for the old Azure portal, which was
+retired in 2018. Please do not use this library.
+
+This repository has been archived.
+
+## Description
 A library for gathering Azure profile information.
 
-= Prerequisites
+## Prerequisites
 * openssl
 * json
 * nokogiri
 
-= Installation
-gem install azure-profile
+## Installation
+`gem install azure-profile`
 
-= Synopsis
+## Synopsis
+```ruby
 require 'azure/profile'
 
 # Assumes ~/.azure/azureProfile.json exists
@@ -43,8 +50,9 @@ Azure.configure do |config|
   config.subscription_id = dsub.subscription_id
   config.management_endpoint = dsub.management_endpoint
 end
+```
 
-= Details
+## Details
 The azure-profile gem gathers and wraps your Azure subscription information.
 Specifically, it will parse information out of your azureProfile.json file
 if present. Alternatively, you can have it use a publishsettings file instead.
@@ -52,7 +60,7 @@ if present. Alternatively, you can have it use a publishsettings file instead.
 With that information you can pass the credentials of the subscription of
 your choice to whatever Azure interface you're using, such as the azure gem.
 
-= Getting a publishsettings file
+## Getting a publishsettings file
 If you want to download a publishsettings file, point your browser at:
 
 https://manage.windowsazure.com/publishsettings/index
@@ -66,28 +74,28 @@ If you're a powershell user, you can do Get-AzurePublishSettingsFile instead.
 A publishsettings file is a simple XML file, so feel free to inspect it
 at your convenience.
 
-= Getting an azureProfile.json file
+## Getting an azureProfile.json file
 If you've installed and used the cross-platform command line interface, then
 you should already have this file. If not, the best way to get one is to install
 and login using the command line interface.
 
 http://azure.microsoft.com/en-us/documentation/articles/xplat-cli/
 
-= Future Plans
-  Allow the option to specify a username and password to automatically
-  retrieve a publishsettings file if one isn't found.
+## Future Plans (obsolete)
+Allow the option to specify a username and password to automatically
+retrieve a publishsettings file if one isn't found.
 
-= Acknowledgements
-  This library possible courtesy of Red Hat, Inc.
+## Acknowledgements
+This library possible courtesy of Red Hat, Inc.
 
-= License
-  Artistic 2.0
+## License
+Apache-2.0
 
-== Warranty
-  This library is provided "as is" and without any express or
-  implied warranties, including, without limitation, the implied
-  warranties of merchantability and fitness for a particular purpose.
+##= Warranty
+This library is provided "as is" and without any express or
+implied warranties, including, without limitation, the implied
+warranties of merchantability and fitness for a particular purpose.
 
-= Authors
+## Authors
 * Daniel Berger
 * Bronagh Sorota

--- a/azure-profile.gemspec
+++ b/azure-profile.gemspec
@@ -4,14 +4,12 @@ Gem::Specification.new do |spec|
   spec.name       = 'azure-profile'
   spec.version    = '1.0.2'
   spec.authors    = ['Daniel J. Berger', 'Bronagh Sorota']
-  spec.license    = 'Apache 2.0'
+  spec.license    = 'Apache-2.0'
   spec.homepage   = 'http://github.com/djberg96/azure-profile'
   spec.summary    = 'An interface for Azure authentication information'
   spec.test_file  = 'spec/azure_profile_spec.rb'
   spec.files      = Dir['**/*'].delete_if{ |item| item.include?('git') }
   spec.cert_chain = ['certs/djberg96_pub.pem']
-
-  spec.extra_rdoc_files = ['CHANGES', 'README', 'MANIFEST']
 
   spec.add_dependency('json')
   spec.add_dependency('nokogiri')


### PR DESCRIPTION
Convert the doc files to markdown, update the gemspec, fix the missing hyphen in the license name.